### PR TITLE
Fix reload job with old data during typing

### DIFF
--- a/src/components/Alarm.vue
+++ b/src/components/Alarm.vue
@@ -134,7 +134,11 @@
       wsConnected() {
         console.log(`WebSocket connection state changed. Connected: ${this.wsConnected}`)
         if (this.wsConnected) {
-          this.loadJobFromServer()
+          if (!this.haveDataToSave) {
+            this.loadJobFromServer()
+          } else {
+            console.log('Not loading job from server, because haveDataToSave is true');
+          }
         }
       }
     },


### PR DESCRIPTION
Nach connect vom WebSocket, was auch während des Betriebs passieren kann, den Job nur dann laden, wenn keine Daten zum Speichern vorhanden sind